### PR TITLE
Breaking change: Deprecated ColumnNames in DbParentRelationDefinition…

### DIFF
--- a/src/RedOrb/IDbTableDefinition.cs
+++ b/src/RedOrb/IDbTableDefinition.cs
@@ -168,20 +168,9 @@ public static class IDbTableDefinitionExtention
 			var def = ObjectRelationMapper.FindFirst(parent.IdentiferType);
 			var pkeys = def.GetPrimaryKeys();
 
-			foreach (var identifer in parent.ParentIdentifers)
+			foreach (var relation in parent.GetParentRelationColumnDefinitions())
 			{
-				var key = pkeys.Where(x => x.Identifer == identifer).FirstOrDefault();
-				if (key == null)
-				{
-					throw new InvalidProgramException($"A column that is not a primary key is specified.(type:{def.Type.FullName}, identifer:{identifer}");
-				}
-				var type = key.RelationColumnType;
-				if (string.IsNullOrEmpty(type))
-				{
-					throw new InvalidProgramException($"RelationColumnType is required when used in a join expression.(type:{def.Type.FullName}, column:{key.ColumnName})");
-				}
-
-				var prop = identifer.ToPropertyInfo(parentType);
+				var prop = relation.Identifer.ToPropertyInfo(parentType);
 				if (parentInstance != null)
 				{
 					var pv = prop.ToParameterValue(parentInstance, placeholderIdentifer);
@@ -192,7 +181,7 @@ public static class IDbTableDefinitionExtention
 					var pv = prop.ToParameterNullValue(placeholderIdentifer);
 					row.Add(pv);
 				}
-				cols.Add(key.ColumnName);
+				cols.Add(relation.ColumnName);
 			}
 		}
 

--- a/src/RedOrb/SelectQueryExtension.cs
+++ b/src/RedOrb/SelectQueryExtension.cs
@@ -57,18 +57,20 @@ internal static class SelectQueryExtension
 		var t = sq.FromClause!.Join(destination.SchemaName, destination.TableName, joinType).As("t" + index).On(x =>
 		{
 			ValueBase? condition = null;
-			for (int i = 0; i < keys.Count; i++)
+
+			foreach (var key in keys)
 			{
 				if (condition == null)
 				{
-					condition = new ColumnValue(fromMap.TableAlias, keys[i].ColumnName);
+					condition = new ColumnValue(fromMap.TableAlias, key.ColumnName);
 				}
 				else
 				{
-					condition.And(fromMap.TableAlias, keys[i].ColumnName);
+					condition.And(fromMap.TableAlias, key.ColumnName);
 				}
-				condition.Equal(x.Table.Alias, keys[i].ColumnName);
+				condition.Equal(x.Table.Alias, key.ColumnName);
 			}
+
 			if (condition == null) throw new InvalidOperationException();
 			return condition;
 		});

--- a/src/RedOrb/SelectQueryExtension.cs
+++ b/src/RedOrb/SelectQueryExtension.cs
@@ -39,8 +39,8 @@ internal static class SelectQueryExtension
 		var destination = ObjectRelationMapper.FindFirst(relation.IdentiferType);
 		bool isNullable = Nullable.GetUnderlyingType(relation.IdentiferType) != null;
 
-		var fromKeys = relation.ColumnNames;
-		var toKeys = destination.GetPrimaryKeys();
+		var keys = destination.GetPrimaryKeys();
+
 		var joinType = isNullable ? "left join" : "inner join";
 
 		var index = sq.GetSelectableTables().Count();
@@ -57,17 +57,17 @@ internal static class SelectQueryExtension
 		var t = sq.FromClause!.Join(destination.SchemaName, destination.TableName, joinType).As("t" + index).On(x =>
 		{
 			ValueBase? condition = null;
-			for (int i = 0; i < fromKeys.Count; i++)
+			for (int i = 0; i < keys.Count; i++)
 			{
 				if (condition == null)
 				{
-					condition = new ColumnValue(fromMap.TableAlias, fromKeys[i]);
+					condition = new ColumnValue(fromMap.TableAlias, keys[i].ColumnName);
 				}
 				else
 				{
-					condition.And(fromMap.TableAlias, fromKeys[i]);
+					condition.And(fromMap.TableAlias, keys[i].ColumnName);
 				}
-				condition.Equal(x.Table.Alias, toKeys[i].ColumnName);
+				condition.Equal(x.Table.Alias, keys[i].ColumnName);
 			}
 			if (condition == null) throw new InvalidOperationException();
 			return condition;

--- a/test/PostgresSample/Model.cs
+++ b/test/PostgresSample/Model.cs
@@ -99,7 +99,7 @@ public static class DbTableDefinitionRepository
 				new () {Identifer = nameof(Post.Content), ColumnName = "content", ColumnType= "text"},
 			},
 			ParentRelations = {
-				new () {Identifer = nameof(Post.Blog), ColumnNames = { "blog_id" } , IdentiferType = typeof(Blog)}
+				new () {Identifer = nameof(Post.Blog), ParentIdentifers = { nameof(Blog.BlogId) } , IdentiferType = typeof(Blog)}
 			},
 			ChildIdentifers = {
 				nameof(Post.Comments)
@@ -118,7 +118,7 @@ public static class DbTableDefinitionRepository
 				new () {Identifer = nameof(Comment.CommentText), ColumnName = "comment_text", ColumnType= "text"},
 			},
 			ParentRelations = {
-				new () {Identifer = nameof(Comment.Post), ColumnNames = { "post_id" } , IdentiferType = typeof(Post)}
+				new () {Identifer = nameof(Comment.Post), ParentIdentifers = { nameof(Post.PostId) } , IdentiferType = typeof(Post)}
 			}
 		};
 	}

--- a/test/PostgresSample/Model.cs
+++ b/test/PostgresSample/Model.cs
@@ -99,7 +99,7 @@ public static class DbTableDefinitionRepository
 				new () {Identifer = nameof(Post.Content), ColumnName = "content", ColumnType= "text"},
 			},
 			ParentRelations = {
-				new () {Identifer = nameof(Post.Blog), ParentIdentifers = { nameof(Blog.BlogId) } , IdentiferType = typeof(Blog)}
+				new () {Identifer = nameof(Post.Blog), IdentiferType = typeof(Blog)}
 			},
 			ChildIdentifers = {
 				nameof(Post.Comments)
@@ -118,7 +118,7 @@ public static class DbTableDefinitionRepository
 				new () {Identifer = nameof(Comment.CommentText), ColumnName = "comment_text", ColumnType= "text"},
 			},
 			ParentRelations = {
-				new () {Identifer = nameof(Comment.Post), ParentIdentifers = { nameof(Post.PostId) } , IdentiferType = typeof(Post)}
+				new () {Identifer = nameof(Comment.Post), IdentiferType = typeof(Post)}
 			}
 		};
 	}


### PR DESCRIPTION
… class. Changed to ParentIdentifers. #13

Column names are often specified by hand, making maintainability difficult. Since Identifer can be obtained using the nameof<T> function, the specifications will be changed.