### PR TITLE
ObjectRelationMapper.AddTypeHandler hook

### DIFF
--- a/src/RedOrb/ObjectRelationMapper.cs
+++ b/src/RedOrb/ObjectRelationMapper.cs
@@ -8,6 +8,8 @@ public static class ObjectRelationMapper
 
 	public static int Timeout { get; set; } = 30;
 
+	public static Func<DbTableDefinition, DbTableDefinition>? Converter { get; set; }
+
 	private static ConcurrentDictionary<Type, DbTableDefinition> Map { get; set; } = new();
 
 	public static void AddTypeHandler<T>(DbTableDefinition<T> def)
@@ -19,7 +21,14 @@ public static class ObjectRelationMapper
 			throw new ArgumentException($"Type '{type.FullName}' is already registered with ObjectRelationMapper.");
 		}
 
-		Map.GetOrAdd(type, def);
+		if (Converter != null)
+		{
+			Map.GetOrAdd(type, Converter(def));
+		}
+		else
+		{
+			Map.GetOrAdd(type, def);
+		}
 	}
 
 	public static DbTableDefinition<T> FindFirst<T>()

--- a/src/RedOrb/RedOrb.csproj
+++ b/src/RedOrb/RedOrb.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright (c) MSugiura 2023</Copyright>
     <PackageReleaseNotes></PackageReleaseNotes>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
     <Authors>MSugiura</Authors>
     <Description>simply object relation mapping framework.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/test/PostgresSample/UnitTestInitializer.cs
+++ b/test/PostgresSample/UnitTestInitializer.cs
@@ -9,8 +9,18 @@ internal static class UnitTestInitializer
 	public static void Initialize()
 	{
 		ObjectRelationMapper.PlaceholderIdentifer = ":";
+		ObjectRelationMapper.Converter = Converter;
 		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetBlogDefinition());
 		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetPostDefinition());
 		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetCommentDefinition());
+	}
+
+	private static DbTableDefinition Converter(DbTableDefinition def)
+	{
+		//foreach (var item in def.ColumnDefinitions) 
+		//{
+		//	item.ColumnName = item.ColumnName.ToUpper();
+		//}
+		return def;
 	}
 }


### PR DESCRIPTION
Added converter to ObjectRelationMapper class.
Converter is called after AddTypeHandler executes but before the definition is registered.