### PR TITLE
Correction of search condition judgment process

### DIFF
--- a/src/RedOrb/DbIndexDefinition.cs
+++ b/src/RedOrb/DbIndexDefinition.cs
@@ -21,7 +21,6 @@ public class DbIndexDefinition
 				sb.Append(", ");
 			}
 			sb.Append(x);
-
 		});
 
 		var sql = @$"create {indextype} if not exists {indexname} on {table.GetTableFullName()} ({sb})";

--- a/src/RedOrb/IDbConnectionExtension.cs
+++ b/src/RedOrb/IDbConnectionExtension.cs
@@ -265,7 +265,7 @@ public static class IDbConnectionExtension
 	{
 		var pkeymaps = GetPrimaryKeyValueMaps(instance);
 
-		if (!pkeymaps.Where(x => x.Value == null).Any())
+		if (!pkeymaps.Where(x => x.IsEmpty()).Any())
 		{
 			return connection.Fetch<T>(pkeymaps, rule);
 		}

--- a/src/RedOrb/RedOrb.csproj
+++ b/src/RedOrb/RedOrb.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright (c) MSugiura 2023</Copyright>
     <PackageReleaseNotes></PackageReleaseNotes>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>0.5.6</Version>
+    <Version>0.5.7</Version>
     <Authors>MSugiura</Authors>
     <Description>simply object relation mapping framework.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/RedOrb/ValueMap.cs
+++ b/src/RedOrb/ValueMap.cs
@@ -5,4 +5,13 @@ public class ValueMap
 	public required string Identifer { get; set; }
 	public required string ColumnName { get; set; }
 	public object? Value { get; set; }
+
+	public bool IsEmpty()
+	{
+		if (Value == null) return true;
+		var v = Value.ToString();
+		if (string.IsNullOrEmpty(v)) return true;
+		if (long.TryParse(v, out var id) && id == 0) return true;
+		return false;
+	}
 }

--- a/test/PostgresSample/CascadeRuleTest.cs
+++ b/test/PostgresSample/CascadeRuleTest.cs
@@ -41,7 +41,7 @@ public class CascadeRuleTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedComment = cn.Load<Comment>(x =>
 		{
-			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId!.Value));
+			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId));
 		}).First();
 
 		Assert.Equal(loadedComment.CommentId, newComment.CommentId);
@@ -70,7 +70,7 @@ public class CascadeRuleTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedComment = cn.Load<Comment>(x =>
 		{
-			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId!.Value));
+			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId));
 		}, rule: new NoCascadeReadRule()).First();
 
 		Assert.Equal(loadedComment.CommentId, newComment.CommentId);
@@ -103,7 +103,7 @@ public class CascadeRuleTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedComment = cn.Load<Comment>(x =>
 		{
-			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId!.Value));
+			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId));
 		}, rule).First();
 
 		Assert.Equal(loadedComment.CommentId, newComment.CommentId);
@@ -138,7 +138,7 @@ public class CascadeRuleTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedComment = cn.Load<Comment>(x =>
 		{
-			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId!.Value));
+			x.Where(x.FromClause!, "comment_id").Equal(x.AddParameter(":id", newComment.CommentId));
 		}, rule).First();
 
 		Assert.Equal(loadedComment.CommentId, newComment.CommentId);

--- a/test/PostgresSample/CascadeTest.cs
+++ b/test/PostgresSample/CascadeTest.cs
@@ -35,13 +35,13 @@ public class CascadeTest : IClassFixture<PostgresDB>
 		var newPost = new Post { Title = "Hello Carbunql", Content = "I wrote an app using RedOrb!" };
 		newBlog.Posts.Add(newPost);
 
-		Assert.Null(newBlog.BlogId);
-		Assert.Null(newPost.Blog.BlogId);
-		Assert.Null(newPost.PostId);
+		Assert.Equal(0, newBlog.BlogId);
+		Assert.Equal(0, newPost.Blog.BlogId);
+		Assert.Equal(0, newPost.PostId);
 		cn.Save(newBlog);
-		Assert.NotNull(newBlog.BlogId);
-		Assert.NotNull(newPost.Blog.BlogId);
-		Assert.NotNull(newPost.PostId);
+		Assert.NotEqual(0, newBlog.BlogId);
+		Assert.NotEqual(0, newPost.Blog.BlogId);
+		Assert.NotEqual(0, newPost.PostId);
 		Assert.Equal(newBlog.BlogId, newPost.Blog.BlogId);
 	}
 
@@ -64,7 +64,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 			var def = ObjectRelationMapper.FindFirst<Post>();
 			var parent = def.ParentRelationDefinitions.Where(x => x.Identifer == nameof(Post.Blog)).First();
 			var column = parent.Relations.Where(x => x.ParentIdentifer == nameof(Blog.BlogId)).First().ColumnName;
-			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId!.Value));
+			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId));
 		}).First();
 
 		Assert.Equal(newPost.PostId, loadedPost.PostId);
@@ -97,7 +97,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 			var parent = def.ParentRelationDefinitions.Where(x => x.Identifer == nameof(Post.Blog)).First();
 			var column = parent.Relations.Where(x => x.ParentIdentifer == nameof(Blog.BlogId)).First().ColumnName;
 
-			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId!.Value));
+			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId));
 		}).First();
 
 		Assert.Equal(newPost.PostId, loadedPost.PostId);
@@ -129,7 +129,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 			var parent = def.ParentRelationDefinitions.Where(x => x.Identifer == nameof(Post.Blog)).First();
 			var column = parent.Relations.Where(x => x.ParentIdentifer == nameof(Blog.BlogId)).First().ColumnName;
 
-			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId!.Value));
+			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newPost.Blog.BlogId));
 		}).FirstOrDefault();
 
 		Assert.Null(loadedPost);
@@ -214,7 +214,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 			var def = ObjectRelationMapper.FindFirst<Blog>();
 			var column = def.ColumnDefinitions.Where(x => x.Identifer == nameof(Blog.BlogId)).First().ColumnName;
 
-			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId!.Value));
+			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();
 
 		Assert.Empty(loadedBlog.Posts);
@@ -250,7 +250,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 			var def = ObjectRelationMapper.FindFirst<Blog>();
 			var column = def.ColumnDefinitions.Where(x => x.Identifer == nameof(Blog.BlogId)).First().ColumnName;
 
-			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId!.Value));
+			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();
 		cn.Fetch(loadedBlog, nameof(loadedBlog.Posts));
 

--- a/test/PostgresSample/DefaultTest.cs
+++ b/test/PostgresSample/DefaultTest.cs
@@ -31,9 +31,9 @@ public class DefaultTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Inserting a new blog");
 		var newBlog = new Blog { Url = "http://blogs.msdn.com/adonet/DefaultTest/CreateTest" };
 
-		Assert.Null(newBlog.BlogId);
+		Assert.Equal(0, newBlog.BlogId);
 		cn.Save(newBlog);
-		Assert.NotNull(newBlog.BlogId);
+		Assert.NotEqual(0, newBlog.BlogId);
 	}
 
 	[Fact]
@@ -86,7 +86,7 @@ public class DefaultTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedBlog = cn.Load<Blog>(x =>
 		{
-			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId!.Value));
+			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();
 
 		Assert.Equal(newBlog.BlogId, loadedBlog.BlogId);
@@ -118,7 +118,7 @@ public class DefaultTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedBlog = cn.Load<Blog>(x =>
 		{
-			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId!.Value));
+			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();
 
 		Assert.Equal(newBlog.BlogId, loadedBlog.BlogId);
@@ -144,7 +144,7 @@ public class DefaultTest : IClassFixture<PostgresDB>
 		Logger.LogInformation("Querying for a blog");
 		var loadedBlog = cn.Load<Blog>(x =>
 		{
-			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId!.Value));
+			x.Where(x.FromClause!, "blog_id").Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).FirstOrDefault();
 
 		Assert.Null(loadedBlog);

--- a/test/PostgresSample/LoadTest.cs
+++ b/test/PostgresSample/LoadTest.cs
@@ -96,8 +96,8 @@ public class LoadTest : IClassFixture<PostgresDB>
 		{
 			// Read
 			Logger.LogInformation("Querying for a blog");
-			var loadedBlog = cn.Load(new Blog() { BlogId = 0 });
+			var loadedBlog = cn.Load(new Blog() { BlogId = -1 });
 		});
-		Assert.Equal("No records found.(BlogId=0)", ex.Message);
+		Assert.Equal("No records found.(BlogId=-1)", ex.Message);
 	}
 }

--- a/test/PostgresSample/Model.cs
+++ b/test/PostgresSample/Model.cs
@@ -14,7 +14,7 @@ namespace PostgresSample;
 public partial class Blog
 {
 	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
-	public int? BlogId { get; set; }
+	public int BlogId { get; set; }
 	[DbColumn("text")]
 	public string Url { get; set; } = string.Empty;
 	[DbColumn("timestamp", SpecialColumn = SpecialColumn.CreateTimestamp, DefaultValue = "clock_timestamp()")]
@@ -33,7 +33,7 @@ public partial class Blog
 public partial class Post
 {
 	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
-	public int? PostId { get; set; }
+	public int PostId { get; set; }
 	[DbParentRelationColumn("bigint", nameof(Post.Blog.BlogId))]
 	public Blog Blog { get; set; } = null!;
 	[DbColumn("text")]
@@ -49,7 +49,7 @@ public partial class Post
 public class Comment
 {
 	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
-	public int? CommentId { get; set; }
+	public int CommentId { get; set; }
 	[DbColumn("text")]
 	public string CommentText { get; set; } = string.Empty;
 	[DbParentRelationColumn("owner_post_id", "bigint", nameof(Comment.Post.PostId))]


### PR DESCRIPTION
When searching, if the primary key value is zero, it is assumed to be unspecified and a unique search is performed.