### PR TITLE
Adapt to Carbunql v0.7

### DIFF
--- a/src/RedOrb/Attributes/DbColumnAttribute.cs
+++ b/src/RedOrb/Attributes/DbColumnAttribute.cs
@@ -1,51 +1,45 @@
-﻿using System.Reflection;
+﻿using Carbunql;
+using System.Reflection;
 
 namespace RedOrb.Attributes;
 
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public class DbColumnAttribute : Attribute
 {
-	public DbColumnAttribute(string columnType)
-	{
-		ColumnType = columnType;
-	}
+    public DbColumnAttribute(string columnType)
+    {
+        ColumnType = columnType;
+    }
 
-	public string ColumnName { get; set; } = string.Empty;
+    public string ColumnName { get; set; } = string.Empty;
 
-	public string ColumnType { get; set; }
+    public string ColumnType { get; set; }
 
-	public string RelationColumnType { get; set; } = string.Empty;
+    public string RelationColumnType { get; set; } = string.Empty;
 
-	public bool IsPrimaryKey { get; set; } = false;
+    public bool IsAutoNumber { get; set; } = false;
 
-	public bool IsUniqueKey { get; set; } = false;
+    public string DefaultValue { get; set; } = string.Empty;
 
-	public bool IsAutoNumber { get; set; } = false;
+    public string Comment { get; set; } = string.Empty;
 
-	public string DefaultValue { get; set; } = string.Empty;
+    public string TimestampCommand { get; set; } = string.Empty;
 
-	public string Comment { get; set; } = string.Empty;
+    public SpecialColumn SpecialColumn { get; set; } = SpecialColumn.None;
 
-	public string TimestampCommand { get; set; } = string.Empty;
-
-	public SpecialColumn SpecialColumn { get; set; } = SpecialColumn.None;
-
-	public DbColumnDefinition ToDefinition(PropertyInfo prop)
-	{
-		var c = new DbColumnDefinition()
-		{
-			Identifer = prop.Name,
-			IsNullable = (IsPrimaryKey) ? false : prop.IsNullable(),
-			ColumnName = (!string.IsNullOrEmpty(ColumnName)) ? ColumnName : prop.Name.ToSnakeCase(),
-			ColumnType = ColumnType,
-			RelationColumnType = RelationColumnType,
-			Comment = Comment,
-			DefaultValue = DefaultValue,
-			IsAutoNumber = IsAutoNumber,
-			IsPrimaryKey = IsPrimaryKey,
-			IsUniqueKey = IsUniqueKey,
-			SpecialColumn = SpecialColumn,
-		};
-		return c;
-	}
+    public DbColumnDefinition ToDefinition(PropertyInfo prop)
+    {
+        var c = new DbColumnDefinition()
+        {
+            Identifier = prop.Name,
+            ColumnName = (!string.IsNullOrEmpty(ColumnName)) ? ColumnName : prop.Name.ToSnakeCase(),
+            ColumnType = ColumnType,
+            RelationColumnType = RelationColumnType,
+            Comment = Comment,
+            DefaultValue = DefaultValue,
+            IsAutoNumber = IsAutoNumber,
+            SpecialColumn = SpecialColumn,
+        };
+        return c;
+    }
 }

--- a/src/RedOrb/Attributes/DbColumnAttribute.cs
+++ b/src/RedOrb/Attributes/DbColumnAttribute.cs
@@ -1,5 +1,4 @@
-﻿using Carbunql;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace RedOrb.Attributes;
 

--- a/src/RedOrb/Attributes/DbIndexAttribute.cs
+++ b/src/RedOrb/Attributes/DbIndexAttribute.cs
@@ -3,27 +3,24 @@
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
 public class DbIndexAttribute : Attribute
 {
-	public DbIndexAttribute(params string[] identifers)
+	public DbIndexAttribute(params string[] identifiers)
 	{
-		Identifers = identifers;
+		Identifiers = identifiers;
 	}
 
-	public DbIndexAttribute(bool isUnique, params string[] identifers)
-	{
-		IsUnique = isUnique;
-		Identifers = identifers;
-	}
+	public string[] Identifiers { get; init; }
 
-	public string[] Identifers { get; }
+	public string ConstraintName { get; init; } = string.Empty;
 
-	public bool IsUnique { get; }
+	public bool IsUnique { get; init; } = false;
 
 	public DbIndexDefinition ToDefinition()
 	{
 		var d = new DbIndexDefinition()
 		{
-			Identifers = Identifers.ToList(),
-			IsUnique = IsUnique
+			Identifiers = Identifiers.ToList(),
+			IsUnique = IsUnique,
+			ConstraintName = ConstraintName
 		};
 		return d;
 	}

--- a/src/RedOrb/Attributes/DbParentRelationAttribute.cs
+++ b/src/RedOrb/Attributes/DbParentRelationAttribute.cs
@@ -5,37 +5,33 @@ namespace RedOrb.Attributes;
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public class DbParentRelationAttribute : Attribute
 {
-	public bool IsPrimaryKey { get; set; } = false;
+    public DbParentRelationDefinition ToDefinition(PropertyInfo prop)
+    {
+        var def = new DbParentRelationDefinition()
+        {
+            Identifer = prop.Name,
+            IdentiferType = prop.PropertyType,
+            IsNullable = prop.IsNullable(),
+        };
 
-	public bool IsUniqueKey { get; set; } = false;
+        var columns = prop.GetCustomAttributes<DbParentRelationColumnAttribute>().ToList();
+        if (columns.Count == 0) throw new InvalidProgramException();
 
-	public DbParentRelationDefinition ToDefinition(PropertyInfo prop)
-	{
-		var def = new DbParentRelationDefinition()
-		{
-			Identifer = prop.Name,
-			IdentiferType = prop.PropertyType,
-			IsNullable = prop.IsNullable(),
-		};
+        foreach (var column in columns)
+        {
+            def.Relations.Add(column.ToDefinition(prop, this));
+        }
 
-		var columns = prop.GetCustomAttributes<DbParentRelationColumnAttribute>().ToList();
-		if (columns.Count == 0) throw new InvalidProgramException();
+        return def;
+    }
 
-		foreach (var column in columns)
-		{
-			def.Relations.Add(column.ToDefinition(prop, this));
-		}
-
-		return def;
-	}
-
-	public static DbParentRelationAttribute CreateDefault()
-	{
-		var attr = new DbParentRelationAttribute()
-		{
-			IsPrimaryKey = false,
-			IsUniqueKey = false,
-		};
-		return attr;
-	}
+    public static DbParentRelationAttribute CreateDefault()
+    {
+        var attr = new DbParentRelationAttribute()
+        {
+            //IsPrimaryKey = false,
+            //IsUniqueKey = false,
+        };
+        return attr;
+    }
 }

--- a/src/RedOrb/Attributes/DbParentRelationColumnAttribute.cs
+++ b/src/RedOrb/Attributes/DbParentRelationColumnAttribute.cs
@@ -5,44 +5,42 @@ namespace RedOrb.Attributes;
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
 public class DbParentRelationColumnAttribute : Attribute
 {
-	public DbParentRelationColumnAttribute(string columnType, string parentIdentifer)
-	{
-		ColumnType = columnType;
-		ParentIdentifer = parentIdentifer;
-	}
+    public DbParentRelationColumnAttribute(string columnType, string parentIdentifer)
+    {
+        ColumnType = columnType;
+        ParentIdentifer = parentIdentifer;
+    }
 
-	public DbParentRelationColumnAttribute(string columnName, string columnType, string parentIdentifer)
-	{
-		ColumnName = columnName;
-		ColumnType = columnType;
-		ParentIdentifer = parentIdentifer;
-	}
+    public DbParentRelationColumnAttribute(string columnName, string columnType, string parentIdentifer)
+    {
+        ColumnName = columnName;
+        ColumnType = columnType;
+        ParentIdentifer = parentIdentifer;
+    }
 
-	public string ColumnName { get; set; } = string.Empty;
+    public string ColumnName { get; set; } = string.Empty;
 
-	public string ParentIdentifer { get; set; }
+    public string ParentIdentifer { get; set; }
 
-	public string ColumnType { get; set; }
+    public string ColumnType { get; set; }
 
-	public string Comment { get; set; } = string.Empty;
+    public string Comment { get; set; } = string.Empty;
 
-	public DbParentRelationColumnDefinition ToDefinition(PropertyInfo prop, DbParentRelationAttribute relation)
-	{
-		var d = new DbParentRelationColumnDefinition()
-		{
-			Identifer = string.Empty,
-			ColumnName = !string.IsNullOrEmpty(ColumnName) ? ColumnName : prop.Name.ToSnakeCase() + "_id",
-			ColumnType = ColumnType,
-			ParentIdentifer = ParentIdentifer,
-			Comment = Comment,
-			IsPrimaryKey = relation.IsPrimaryKey,
-			IsUniqueKey = relation.IsUniqueKey,
-			IsNullable = prop.IsNullable(),
-			DefaultValue = string.Empty,
-			IsAutoNumber = false,
-			RelationColumnType = ColumnType,
-			SpecialColumn = SpecialColumn.ParentRelation
-		};
-		return d;
-	}
+    public DbParentRelationColumnDefinition ToDefinition(PropertyInfo prop, DbParentRelationAttribute relation)
+    {
+        var d = new DbParentRelationColumnDefinition()
+        {
+            Identifier = string.Empty,
+            ColumnName = !string.IsNullOrEmpty(ColumnName) ? ColumnName : prop.Name.ToSnakeCase() + "_id",
+            ColumnType = ColumnType,
+            ParentIdentifer = ParentIdentifer,
+            Comment = Comment,
+            IsNullable = prop.IsNullable(),
+            DefaultValue = string.Empty,
+            IsAutoNumber = false,
+            RelationColumnType = ColumnType,
+            SpecialColumn = SpecialColumn.ParentRelation
+        };
+        return d;
+    }
 }

--- a/src/RedOrb/Attributes/DbTableAttribute.cs
+++ b/src/RedOrb/Attributes/DbTableAttribute.cs
@@ -1,27 +1,31 @@
-﻿namespace RedOrb.Attributes;
+﻿using Carbunql.Definitions;
+
+namespace RedOrb.Attributes;
 
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-public class DbTableAttribute : Attribute
+public class DbTableAttribute : Attribute, ITable
 {
-	public DbTableAttribute() { }
-
-	public DbTableAttribute(string tableName)
+	public DbTableAttribute(string[] identifiers)
 	{
-		TableName = tableName;
+		Identifiers = identifiers;
 	}
 
-	public string SchemaName { get; set; } = string.Empty;
+	public string[] Identifiers { get; init; }
 
-	public string TableName { get; set; } = string.Empty;
+	public string Schema { get; init; } = string.Empty;
 
-	public string Comment { get; set; } = string.Empty;
+	public string Table { get; internal set; } = string.Empty;
+
+	public string ConstraintName { get; init; } = string.Empty;
+
+	public string Comment { get; init; } = string.Empty;
 
 	public DbTableDefinition<T> ToDefinition<T>()
 	{
 		var d = new DbTableDefinition<T>()
 		{
-			SchemaName = SchemaName,
-			TableName = (!string.IsNullOrEmpty(TableName)) ? TableName : typeof(T).Name.ToSnakeCase(),
+			SchemaName = Schema,
+			TableName = (!string.IsNullOrEmpty(Table)) ? Table : typeof(T).Name.ToSnakeCase(),
 			Comment = Comment,
 		};
 		return d;
@@ -29,10 +33,9 @@ public class DbTableAttribute : Attribute
 
 	public static DbTableAttribute CreateDefault<T>()
 	{
-		var attr = new DbTableAttribute()
-		{
-			TableName = typeof(T).Name.ToSnakeCase(),
-		};
+		var table = typeof(T).Name.ToSnakeCase();
+		var identifiers = new[] { table + "id" };
+		var attr = new DbTableAttribute(identifiers) { Table = table };
 		return attr;
 	}
 }

--- a/src/RedOrb/Attributes/DbTableAttribute.cs
+++ b/src/RedOrb/Attributes/DbTableAttribute.cs
@@ -5,37 +5,37 @@ namespace RedOrb.Attributes;
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public class DbTableAttribute : Attribute, ITable
 {
-	public DbTableAttribute(string[] identifiers)
-	{
-		Identifiers = identifiers;
-	}
+    public DbTableAttribute(string[] identifiers)
+    {
+        PrimaryKeyIdentifiers = identifiers;
+    }
 
-	public string[] Identifiers { get; init; }
+    public string[] PrimaryKeyIdentifiers { get; init; }
 
-	public string Schema { get; init; } = string.Empty;
+    public string Schema { get; init; } = string.Empty;
 
-	public string Table { get; internal set; } = string.Empty;
+    public string Table { get; internal set; } = string.Empty;
 
-	public string ConstraintName { get; init; } = string.Empty;
+    public string ConstraintName { get; init; } = string.Empty;
 
-	public string Comment { get; init; } = string.Empty;
+    public string Comment { get; init; } = string.Empty;
 
-	public DbTableDefinition<T> ToDefinition<T>()
-	{
-		var d = new DbTableDefinition<T>()
-		{
-			SchemaName = Schema,
-			TableName = (!string.IsNullOrEmpty(Table)) ? Table : typeof(T).Name.ToSnakeCase(),
-			Comment = Comment,
-		};
-		return d;
-	}
+    public DbTableDefinition<T> ToDefinition<T>()
+    {
+        var d = new DbTableDefinition<T>()
+        {
+            SchemaName = Schema,
+            TableName = (!string.IsNullOrEmpty(Table)) ? Table : typeof(T).Name.ToSnakeCase(),
+            Comment = Comment,
+        };
+        return d;
+    }
 
-	public static DbTableAttribute CreateDefault<T>()
-	{
-		var table = typeof(T).Name.ToSnakeCase();
-		var identifiers = new[] { table + "id" };
-		var attr = new DbTableAttribute(identifiers) { Table = table };
-		return attr;
-	}
+    public static DbTableAttribute CreateDefault<T>()
+    {
+        var table = typeof(T).Name.ToSnakeCase();
+        var pkeys = new[] { table + "id" };
+        var attr = new DbTableAttribute(pkeys) { Table = table };
+        return attr;
+    }
 }

--- a/src/RedOrb/Attributes/DefinitionBuilder.cs
+++ b/src/RedOrb/Attributes/DefinitionBuilder.cs
@@ -46,7 +46,7 @@ public static class DefinitionBuilder
 		{
 			var children = prop.GetCustomAttribute<DbChildrenAttribute>();
 			if (children == null) continue;
-			def.ChildIdentifers.Add(prop.Name);
+			def.ChildIdentifiers.Add(prop.Name);
 		}
 
 		return def;

--- a/src/RedOrb/DbColumnDefinition.cs
+++ b/src/RedOrb/DbColumnDefinition.cs
@@ -4,7 +4,7 @@ namespace RedOrb;
 
 public class DbColumnDefinition : IDbColumnContainer
 {
-	public string Identifer { get; set; } = string.Empty;
+	public string Identifier { get; set; } = string.Empty;
 
 	public required string ColumnName { get; set; }
 
@@ -14,11 +14,13 @@ public class DbColumnDefinition : IDbColumnContainer
 
 	public bool IsNullable { get; set; } = false;
 
-	public bool IsPrimaryKey { get; set; } = false;
+	//public bool IsPrimaryKey { get; set; } = false;
 
-	public bool IsUniqueKey { get; set; } = false;
+	//public bool IsUniqueKey { get; set; } = false;
 
 	public bool IsAutoNumber { get; set; } = false;
+
+	public string AutoNumberCommand { get; set; } = string.Empty;
 
 	public string DefaultValue { get; set; } = string.Empty;
 

--- a/src/RedOrb/DbTableDefinition.cs
+++ b/src/RedOrb/DbTableDefinition.cs
@@ -25,6 +25,8 @@ public class DbTableDefinition : IDbTableDefinition
 		}
 	}
 
+	public List<string> PKeyIdentifiers { get; init; } = new();
+
 	public List<DbIndexDefinition> Indexes { get; init; } = new();
 
 	public IEnumerable<DbParentRelationDefinition> ParentRelationDefinitions => GetParentRelations();
@@ -37,9 +39,9 @@ public class DbTableDefinition : IDbTableDefinition
 		}
 	}
 
-	public List<string> ChildIdentifers { get; init; } = new();
+	public List<string> ChildIdentifiers { get; init; } = new();
 
-	public virtual Type Type { get; } = null!;
+	public virtual Type Type { get; } = typeof(object);
 
 	public string TableFullName => GetTableFullName();
 

--- a/src/RedOrb/ExpressionAnalyzer.cs
+++ b/src/RedOrb/ExpressionAnalyzer.cs
@@ -1,8 +1,8 @@
 ﻿using Carbunql.Extensions;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace RedOrb;
 

--- a/src/RedOrb/IDbTableDefinition.cs
+++ b/src/RedOrb/IDbTableDefinition.cs
@@ -94,7 +94,7 @@ public static class IDbTableDefinitionExtention
         }
 
         var columns = new List<string>();
-        foreach (var id in table.Identifiers)
+        foreach (var id in table.PrimaryKeyIdentifiers)
         {
             var c = source.ColumnDefinitions.Where(x => x.Identifier == id).First();
             columns.Add(c.ColumnName);
@@ -198,7 +198,7 @@ public static class IDbTableDefinitionExtention
     public static List<DbColumnDefinition> GetPrimaryKeys(this IDbTableDefinition source)
     {
         var table = source.GetDbTableAttribute();
-        return source.ColumnDefinitions.Where(x => table.Identifiers.Contains(x.Identifier)).ToList();
+        return source.ColumnDefinitions.Where(x => table.PrimaryKeyIdentifiers.Contains(x.Identifier)).ToList();
     }
 
     public static List<DbIndexDefinition> GetUniqueKeyIndexes(this IDbTableDefinition source)

--- a/src/RedOrb/IDbTableDefinition.cs
+++ b/src/RedOrb/IDbTableDefinition.cs
@@ -1,279 +1,388 @@
 ﻿using Carbunql;
 using Carbunql.Analysis.Parser;
 using Carbunql.Building;
+using Carbunql.Clauses;
+using Carbunql.Definitions;
 using Carbunql.Values;
-using Cysharp.Text;
 using RedOrb;
+using RedOrb.Attributes;
 using RedOrb.Mapping;
+using System;
+using System.Reflection;
 
 namespace RedOrb;
 
 public interface IDbTableDefinition : IDbTable
 {
-	IEnumerable<DbColumnDefinition> ColumnDefinitions { get; }
+    IEnumerable<DbColumnDefinition> ColumnDefinitions { get; }
 
-	List<DbIndexDefinition> Indexes { get; }
+    List<DbIndexDefinition> Indexes { get; }
 
-	Type Type { get; }
+    List<string> PKeyIdentifiers { get; }
 
-	IEnumerable<DbParentRelationDefinition> ParentRelationDefinitions { get; }
+    Type Type { get; }
 
-	List<string> ChildIdentifers { get; }
+    IEnumerable<DbParentRelationDefinition> ParentRelationDefinitions { get; }
+
+    List<string> ChildIdentifiers { get; }
 }
 
 public static class IDbTableDefinitionExtention
 {
-	public static string ToCreateTableCommandText(this IDbTableDefinition source)
-	{
-		var table = ValueParser.Parse(source.GetTableFullName()).ToText();
+    public static DbTableAttribute GetDbTableAttribute(this IDbTableDefinition source)
+    {
+        var table = source.Type.GetCustomAttributes(false).OfType<DbTableAttribute>().FirstOrDefault();
+        if (table == null)
+        {
+            table = new DbTableAttribute(source.PKeyIdentifiers.ToArray())
+            {
+                Schema = source.SchemaName,
+                Table = source.TableName,
+            };
+        }
 
-		var sb = ZString.CreateStringBuilder();
+        if (string.IsNullOrEmpty(table.Table))
+        {
+            table.Table = source.Type.Name.ToSnakeCase();
+        }
+        return table;
+    }
 
-		foreach (var column in source.ColumnDefinitions)
-		{
-			foreach (var item in column.GetCreateTableCommandTexts())
-			{
-				if (sb.Length > 0) sb.AppendLine(", ");
-				sb.Append("    " + item);
-			}
-		}
+    public static DefinitionQuerySet ToDefinitionQuerySet(this IDbTableDefinition source)
+    {
+        var table = source.GetDbTableAttribute();
 
-		var pkeys = source.ColumnDefinitions.Where(x => x.IsPrimaryKey).ToList();
-		if (pkeys.Any())
-		{
-			var columnText = string.Join(", ", pkeys.Select(x => ValueParser.Parse(x.ColumnName).ToText()));
-			if (sb.Length > 0) sb.AppendLine(", ");
-			sb.Append("    primary key(" + string.Join(", ", columnText) + ")");
-		}
+        var ct = new CreateTableQuery(table)
+        {
+            HasIfNotExists = true
+        };
+        ct.DefinitionClause = new(ct);
 
-		var ukeys = source.ColumnDefinitions.Where(x => x.IsUniqueKey).ToList();
-		if (ukeys.Any())
-		{
-			var columnText = string.Join(", ", ukeys.Select(x => ValueParser.Parse(x.ColumnName).ToText()));
-			if (sb.Length > 0) sb.AppendLine(", ");
-			sb.Append("    unique(" + string.Join(", ", columnText) + ")");
-		}
+        source.GetColumnDefinitions(table).ToList().ForEach(x => ct.DefinitionClause.Add(x));
+        ct.DefinitionClause.Add(source.GetPKeyConstraint(table));
 
-		var sql = @$"create table if not exists {table} (
-{sb}
-)";
-		return sql;
-	}
+        var qs = new DefinitionQuerySet(ct);
+        source.GetIndexQueries(table).ToList().ForEach(qs.AddAlterIndexQuery);
+        source.GetRelationIndexQueries(table).ToList().ForEach(qs.AddAlterIndexQuery);
+        return qs;
+    }
 
-	public static IEnumerable<string> ToCreateIndexCommandTexts(this IDbTableDefinition source)
-	{
-		var id = 0;
-		foreach (var index in source.Indexes)
-		{
-			id++;
-			yield return index.ToCommandText(source, id);
-		}
-	}
+    public static IEnumerable<ColumnDefinition> GetColumnDefinitions(this IDbTableDefinition source, DbTableAttribute table)
+    {
+        foreach (var column in source.ColumnDefinitions)
+        {
+            var c = new ColumnDefinition(table, column.ColumnName, column.ColumnType)
+            {
+                IsNullable = column.IsNullable,
+            };
+            if (!string.IsNullOrEmpty(column.AutoNumberCommand))
+            {
+                c.AutoNumberDefinition = ValueParser.Parse(column.AutoNumberCommand);
+            }
+            if (!string.IsNullOrEmpty(column.DefaultValue))
+            {
+                c.DefaultValue = ValueParser.Parse(column.DefaultValue);
+            }
+            yield return c;
+        }
+    }
 
-	public static string GetColumnName(this IDbTableDefinition source, string identifer)
-	{
-		return source.ColumnDefinitions.Where(x => x.Identifer == identifer).Select(x => x.ColumnName).First();
-	}
+    public static PrimaryKeyConstraint GetPKeyConstraint(this IDbTableDefinition source, DbTableAttribute table)
+    {
+        var name = table.ConstraintName;
+        if (string.IsNullOrEmpty(name))
+        {
+            name = $"pk_{table.Table}";
+        }
 
-	public static DbColumnDefinition? GetSequenceOrDefault(this IDbTableDefinition source)
-	{
-		return source.ColumnDefinitions.Where(x => x.IsAutoNumber).FirstOrDefault();
-	}
+        var columns = new List<string>();
+        foreach (var id in table.Identifiers)
+        {
+            var c = source.ColumnDefinitions.Where(x => x.Identifier == id).First();
+            columns.Add(c.ColumnName);
+        }
+        if (!columns.Any()) throw new InvalidProgramException();
 
-	public static DbColumnDefinition GetSequence(this IDbTableDefinition source)
-	{
-		var seq = source.GetSequenceOrDefault();
-		if (seq == null) throw new NotSupportedException($"Sequence column not defined in {source.GetTableFullName()}");
-		return seq;
-	}
+        return new PrimaryKeyConstraint(table)
+        {
+            ConstraintName = name,
+            ColumnNames = columns
+        };
+    }
 
-	public static List<DbColumnDefinition> GetPrimaryKeys(this IDbTableDefinition source)
-	{
-		var lst = source.ColumnDefinitions.Where(x => x.IsPrimaryKey).ToList();
-		if (!lst.Any()) throw new NotSupportedException($"Primary key column not defined in {source.GetTableFullName()}");
-		return lst;
-	}
+    public static IEnumerable<CreateIndexQuery> GetIndexQueries(this IDbTableDefinition source, DbTableAttribute table)
+    {
+        var indexes = source.Type.GetCustomAttributes(false).OfType<DbIndexAttribute>().ToList();
 
-	public static List<DbIndexDefinition> GetUniqueKeyIndexes(this IDbTableDefinition source)
-	{
-		var lst = source.Indexes.Where(x => x.IsUnique).ToList();
-		if (!lst.Any()) throw new NotSupportedException($"Unique key column not defined in {source.GetTableFullName()}");
-		return lst;
-	}
+        foreach (var index in indexes)
+        {
+            var clause = new IndexOnClause(table);
+            foreach (var id in index.Identifiers)
+            {
+                var c = source.ColumnDefinitions.Where(x => x.Identifier == id).First();
+                clause.Add(ValueParser.Parse(c.ColumnName).ToSortable());
+            }
 
-	private static (SelectQuery, TypeMap) CreateSelectQuery<T>(this DbTableDefinition def)
-	{
-		var map = new TypeMap()
-		{
-			TableAlias = "t0",
-			Type = typeof(T),
-			ColumnMaps = new()
-		};
+            var name = index.ConstraintName;
+            {
+                var num = indexes.IndexOf(index);
+                name = $"i{num}_{table.Table}";
+            }
 
-		var sq = new SelectQuery();
-		var table = ValueParser.Parse(def.GetTableFullName()).ToText();
-		sq.From(table).As(map.TableAlias);
+            yield return new CreateIndexQuery(clause)
+            {
+                IndexName = name,
+                IsUnique = index.IsUnique,
+                HasIfNotExists = true
+            };
+        }
+    }
 
-		sq.AddSelectPrimarykeyColumns(def, map);
-		sq.AddSelectColumnsWithoutPrimaryKeys(def, map);
+    public static IEnumerable<CreateIndexQuery> GetRelationIndexQueries(this IDbTableDefinition source, DbTableAttribute table)
+    {
+        var idx = 0;
+        foreach (var prop in source.Type.GetProperties())
+        {
+            var columns = new List<string>();
+            foreach (var atr in prop.GetCustomAttributes(false).OfType<DbParentRelationColumnAttribute>())
+            {
+                var column = atr.ColumnName;
+                if (string.IsNullOrEmpty(column)) column = prop.Name.ToSnakeCase() + "_id";
+                columns.Add(column);
+            }
+            if (!columns.Any()) continue;
 
-		return (sq, map);
-	}
+            var clause = new IndexOnClause(table);
+            foreach (var item in columns)
+            {
+                clause.Add(ValueParser.Parse(item).ToSortable());
+            }
 
-	public static (SelectQuery Query, List<TypeMap> Maps) ToSelectQueryMap<T>(this DbTableDefinition source, ICascadeReadRule? rule = null)
-	{
-		var (sq, fromMap) = source.CreateSelectQuery<T>();
-		var maps = new List<TypeMap>() { fromMap };
-		var from = sq.FromClause!.Root;
+            var name = $"r{idx}_{table.Table}";
+            idx++;
 
-		rule ??= new FullCascadeReadRule();
+            yield return new CreateIndexQuery(clause)
+            {
+                IndexName = name,
+                HasIfNotExists = true
+            };
+        }
+    }
 
-		source.ParentRelationDefinitions.ToList().ForEach(relation =>
-		{
-			var doCascade = rule.DoCascade(source.Type!, relation.IdentiferType);
-			maps.AddRange(sq.AddJoin(relation, fromMap, rule, doSelectPKeyOnly: !doCascade));
-		});
+    //[Obsolete]
+    //public static IEnumerable<string> ToCreateIndexCommandTexts(this IDbTableDefinition source)
+    //{
+    //	var id = 0;
+    //	foreach (var index in source.Indexes)
+    //	{
+    //		id++;
+    //		yield return index.ToCommandText(source, id);
+    //	}
+    //}
 
-		return (sq, maps);
-	}
+    public static string GetColumnName(this IDbTableDefinition source, string identifer)
+    {
+        return source.ColumnDefinitions.Where(x => x.Identifier == identifer).Select(x => x.ColumnName).First();
+    }
 
-	public static (InsertQuery Query, DbColumnDefinition? Sequence) ToInsertQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
-	{
-		var row = new ValueCollection();
-		var cols = new List<string>();
+    public static DbColumnDefinition? GetSequenceOrDefault(this IDbTableDefinition source)
+    {
+        return source.ColumnDefinitions.Where(x => x.IsAutoNumber).FirstOrDefault();
+    }
 
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.None))
-		{
-			if (string.IsNullOrEmpty(item.Identifer)) continue;
-			if (item.IsAutoNumber) continue;
+    public static DbColumnDefinition GetSequence(this IDbTableDefinition source)
+    {
+        var seq = source.GetSequenceOrDefault();
+        if (seq == null) throw new NotSupportedException($"Sequence column not defined in {source.GetTableFullName()}");
+        return seq;
+    }
 
-			var prop = item.Identifer.ToPropertyInfo<T>();
-			var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+    public static List<DbColumnDefinition> GetPrimaryKeys(this IDbTableDefinition source)
+    {
+        var table = source.GetDbTableAttribute();
+        return source.ColumnDefinitions.Where(x => table.Identifiers.Contains(x.Identifier)).ToList();
+    }
 
-			row.Add(pv);
-			cols.Add(item.ColumnName);
-		}
+    public static List<DbIndexDefinition> GetUniqueKeyIndexes(this IDbTableDefinition source)
+    {
+        var lst = source.Indexes.Where(x => x.IsUnique).ToList();
+        if (!lst.Any()) throw new NotSupportedException($"Unique key column not defined in {source.GetTableFullName()}");
+        return lst;
+    }
 
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.CreateTimestamp || x.SpecialColumn == SpecialColumn.UpdateTimestamp))
-		{
-			if (string.IsNullOrEmpty(item.Identifer)) continue;
-			if (item.IsAutoNumber) continue;
+    private static (SelectQuery, TypeMap) CreateSelectQuery<T>(this DbTableDefinition def)
+    {
+        var map = new TypeMap()
+        {
+            TableAlias = "t0",
+            Type = typeof(T),
+            ColumnMaps = new()
+        };
 
-			var command = !string.IsNullOrEmpty(item.DefaultValue) ? item.DefaultValue : "current_timestamp";
+        var sq = new SelectQuery();
+        var table = ValueParser.Parse(def.GetTableFullName()).ToText();
+        sq.From(table).As(map.TableAlias);
 
-			row.Add(command);
-			cols.Add(item.ColumnName);
-		}
+        sq.AddSelectPrimarykeyColumns(def, map);
+        sq.AddSelectColumnsWithoutPrimaryKeys(def, map);
 
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
-		{
-			row.Add("1");
-			cols.Add(item.ColumnName);
-		}
+        return (sq, map);
+    }
 
-		foreach (var parent in source.ParentRelationDefinitions)
-		{
-			var parentProp = parent.Identifer.ToPropertyInfo<T>();
-			var parentType = parentProp.PropertyType;
-			var parentInstance = parentProp.GetValue(instance);
+    public static (SelectQuery Query, List<TypeMap> Maps) ToSelectQueryMap<T>(this DbTableDefinition source, ICascadeReadRule? rule = null)
+    {
+        var (sq, fromMap) = source.CreateSelectQuery<T>();
+        var maps = new List<TypeMap>() { fromMap };
+        var from = sq.FromClause!.Root;
 
-			var def = ObjectRelationMapper.FindFirst(parent.IdentiferType);
-			var pkeys = def.GetPrimaryKeys();
+        rule ??= new FullCascadeReadRule();
 
-			foreach (var relation in parent.Relations)
-			{
-				var prop = relation.ParentIdentifer.ToPropertyInfo(parentType);
-				if (parentInstance != null)
-				{
-					var pv = prop.ToParameterValue(parentInstance, placeholderIdentifer);
-					row.Add(pv);
-				}
-				else
-				{
-					var pv = prop.ToParameterNullValue(placeholderIdentifer);
-					row.Add(pv);
-				}
-				cols.Add(relation.ColumnName);
-			}
-		}
+        source.ParentRelationDefinitions.ToList().ForEach(relation =>
+        {
+            var doCascade = rule.DoCascade(source.Type!, relation.IdentiferType);
+            maps.AddRange(sq.AddJoin(relation, fromMap, rule, doSelectPKeyOnly: !doCascade));
+        });
 
-		var vq = new ValuesQuery(new List<ValueCollection>() { row });
-		var query = vq.ToSelectQuery(cols).ToInsertQuery(source.GetTableFullName());
+        return (sq, maps);
+    }
 
-		var seq = source.GetSequenceOrDefault();
-		if (seq != null) query.Returning(new ColumnValue(seq.ColumnName));
+    public static (InsertQuery Query, DbColumnDefinition? Sequence) ToInsertQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
+    {
+        var row = new ValueCollection();
+        var cols = new List<string>();
 
-		return (query, seq);
-	}
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.None))
+        {
+            if (string.IsNullOrEmpty(item.Identifier)) continue;
+            if (item.IsAutoNumber) continue;
 
-	public static UpdateQuery ToUpdateQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
-	{
-		var pkeys = source.GetPrimaryKeys();
+            var prop = item.Identifier.ToPropertyInfo<T>();
+            var pv = prop.ToParameterValue(instance, placeholderIdentifer);
 
-		var row = new ValueCollection();
-		var cols = new List<string>();
+            row.Add(pv);
+            cols.Add(item.ColumnName);
+        }
 
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.None || x.SpecialColumn == SpecialColumn.ParentRelation))
-		{
-			if (string.IsNullOrEmpty(item.Identifer)) continue;
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.CreateTimestamp || x.SpecialColumn == SpecialColumn.UpdateTimestamp))
+        {
+            if (string.IsNullOrEmpty(item.Identifier)) continue;
+            if (item.IsAutoNumber) continue;
 
-			var prop = item.Identifer.ToPropertyInfo<T>();
-			var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+            var command = !string.IsNullOrEmpty(item.DefaultValue) ? item.DefaultValue : "current_timestamp";
 
-			row.Add(pv);
-			cols.Add(item.ColumnName);
-		}
+            row.Add(command);
+            cols.Add(item.ColumnName);
+        }
 
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.UpdateTimestamp))
-		{
-			var command = !string.IsNullOrEmpty(item.DefaultValue) ? item.DefaultValue : "current_timestamp";
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
+        {
+            row.Add("1");
+            cols.Add(item.ColumnName);
+        }
 
-			row.Add(command);
-			cols.Add(item.ColumnName);
-		}
+        foreach (var parent in source.ParentRelationDefinitions)
+        {
+            var parentProp = parent.Identifer.ToPropertyInfo<T>();
+            var parentType = parentProp.PropertyType;
+            var parentInstance = parentProp.GetValue(instance);
 
-		// version increment
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
-		{
-			var prop = item.Identifer.ToPropertyInfo<T>();
-			var pv = prop.ToParameterValue(instance, placeholderIdentifer);
-			pv.AddOperatableValue("+", "1");
-			row.Add(pv);
-			cols.Add(item.ColumnName);
-		}
+            var def = ObjectRelationMapper.FindFirst(parent.IdentiferType);
+            var pkeys = def.GetPrimaryKeys();
 
-		var vq = new ValuesQuery(new List<ValueCollection>() { row });
-		var uq = vq.ToSelectQuery(cols).ToUpdateQuery(source.GetTableFullName(), pkeys.Select(x => x.ColumnName));
+            foreach (var relation in parent.Relations)
+            {
+                var prop = relation.ParentIdentifer.ToPropertyInfo(parentType);
+                if (parentInstance != null)
+                {
+                    var pv = prop.ToParameterValue(parentInstance, placeholderIdentifer);
+                    row.Add(pv);
+                }
+                else
+                {
+                    var pv = prop.ToParameterNullValue(placeholderIdentifer);
+                    row.Add(pv);
+                }
+                cols.Add(relation.ColumnName);
+            }
+        }
 
-		// version check
-		foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
-		{
-			var prop = item.Identifer.ToPropertyInfo<T>();
-			var pv = prop.ToParameterValue(instance, placeholderIdentifer);
-			uq.WhereClause!.Condition.And(uq.UpdateClause!.Table.Alias, item.ColumnName).Equal(pv);
-		}
+        var vq = new ValuesQuery(new List<ValueCollection>() { row });
+        var query = vq.ToSelectQuery(cols).ToInsertQuery(source.GetTableFullName());
 
-		return uq;
-	}
+        var seq = source.GetSequenceOrDefault();
+        if (seq != null) query.Returning(new ColumnValue(seq.ColumnName));
 
-	public static DeleteQuery ToDeleteQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
-	{
-		var pkeys = source.GetPrimaryKeys();
+        return (query, seq);
+    }
 
-		var row = new ValueCollection();
-		var cols = new List<string>();
+    public static UpdateQuery ToUpdateQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
+    {
+        var pkeys = source.GetPrimaryKeys();
 
-		foreach (var item in pkeys)
-		{
-			var prop = item.Identifer.ToPropertyInfo<T>();
-			var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+        var row = new ValueCollection();
+        var cols = new List<string>();
 
-			row.Add(pv);
-			cols.Add(item.ColumnName);
-		}
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.None || x.SpecialColumn == SpecialColumn.ParentRelation))
+        {
+            if (string.IsNullOrEmpty(item.Identifier)) continue;
 
-		var vq = new ValuesQuery(new List<ValueCollection>() { row });
-		return vq.ToSelectQuery(cols).ToDeleteQuery(source.GetTableFullName());
-	}
+            var prop = item.Identifier.ToPropertyInfo<T>();
+            var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+
+            row.Add(pv);
+            cols.Add(item.ColumnName);
+        }
+
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.UpdateTimestamp))
+        {
+            var command = !string.IsNullOrEmpty(item.DefaultValue) ? item.DefaultValue : "current_timestamp";
+
+            row.Add(command);
+            cols.Add(item.ColumnName);
+        }
+
+        // version increment
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
+        {
+            var prop = item.Identifier.ToPropertyInfo<T>();
+            var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+            pv.AddOperatableValue("+", "1");
+            row.Add(pv);
+            cols.Add(item.ColumnName);
+        }
+
+        var vq = new ValuesQuery(new List<ValueCollection>() { row });
+        var uq = vq.ToSelectQuery(cols).ToUpdateQuery(source.GetTableFullName(), pkeys.Select(x => x.ColumnName));
+
+        // version check
+        foreach (var item in source.ColumnDefinitions.Where(x => x.SpecialColumn == SpecialColumn.VersionNumber))
+        {
+            var prop = item.Identifier.ToPropertyInfo<T>();
+            var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+            uq.WhereClause!.Condition.And(uq.UpdateClause!.Table.Alias, item.ColumnName).Equal(pv);
+        }
+
+        return uq;
+    }
+
+    public static DeleteQuery ToDeleteQuery<T>(this IDbTableDefinition source, T instance, string placeholderIdentifer)
+    {
+        var pkeys = source.GetPrimaryKeys();
+
+        var row = new ValueCollection();
+        var cols = new List<string>();
+
+        foreach (var item in pkeys)
+        {
+            var prop = item.Identifier.ToPropertyInfo<T>();
+            var pv = prop.ToParameterValue(instance, placeholderIdentifer);
+
+            row.Add(pv);
+            cols.Add(item.ColumnName);
+        }
+
+        var vq = new ValuesQuery(new List<ValueCollection>() { row });
+        return vq.ToSelectQuery(cols).ToDeleteQuery(source.GetTableFullName());
+    }
 }
 

--- a/src/RedOrb/IDbTableDefinition.cs
+++ b/src/RedOrb/IDbTableDefinition.cs
@@ -7,8 +7,6 @@ using Carbunql.Values;
 using RedOrb;
 using RedOrb.Attributes;
 using RedOrb.Mapping;
-using System;
-using System.Reflection;
 
 namespace RedOrb;
 

--- a/src/RedOrb/LoggingDbConnection.cs
+++ b/src/RedOrb/LoggingDbConnection.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Data;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace RedOrb;
 

--- a/src/RedOrb/LoggingDbTransaction.cs
+++ b/src/RedOrb/LoggingDbTransaction.cs
@@ -1,42 +1,41 @@
 ﻿using Microsoft.Extensions.Logging;
 using System.Data;
-using System.Runtime.CompilerServices;
 
 namespace RedOrb;
 
 public class LoggingDbTransaction : IDbTransaction
 {
-	public LoggingDbTransaction(IDbTransaction transaction, ILogger logger)
-	{
-		DbTransaction = transaction;
-		Logger = logger;
-		Logger.Log(LogLevel, nameof(Connection.BeginTransaction));
-	}
+    public LoggingDbTransaction(IDbTransaction transaction, ILogger logger)
+    {
+        DbTransaction = transaction;
+        Logger = logger;
+        Logger.Log(LogLevel, nameof(Connection.BeginTransaction));
+    }
 
-	private ILogger Logger { get; init; }
+    private ILogger Logger { get; init; }
 
-	private IDbTransaction DbTransaction { get; init; }
+    private IDbTransaction DbTransaction { get; init; }
 
-	public LogLevel LogLevel { get; set; } = LogLevel.Information;
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
-	public IDbConnection? Connection => DbTransaction.Connection;
+    public IDbConnection? Connection => DbTransaction.Connection;
 
-	public IsolationLevel IsolationLevel => DbTransaction.IsolationLevel;
+    public IsolationLevel IsolationLevel => DbTransaction.IsolationLevel;
 
-	public void Commit()
-	{
-		DbTransaction.Commit();
-		Logger.Log(LogLevel, nameof(Commit));
-	}
+    public void Commit()
+    {
+        DbTransaction.Commit();
+        Logger.Log(LogLevel, nameof(Commit));
+    }
 
-	public void Rollback()
-	{
-		DbTransaction.Rollback();
-		Logger.Log(LogLevel, nameof(Rollback));
-	}
+    public void Rollback()
+    {
+        DbTransaction.Rollback();
+        Logger.Log(LogLevel, nameof(Rollback));
+    }
 
-	public void Dispose()
-	{
-		DbTransaction.Dispose();
-	}
+    public void Dispose()
+    {
+        DbTransaction.Dispose();
+    }
 }

--- a/src/RedOrb/Mapping/InstanceMap.cs
+++ b/src/RedOrb/Mapping/InstanceMap.cs
@@ -15,27 +15,27 @@ public class InstanceMap
 	public PropertyInfo GetSequenceProperty()
 	{
 		var tp = GetInstanceType();
-		var name = ObjectRelationMapper.FindFirst(tp).GetSequence().Identifer;
+		var name = ObjectRelationMapper.FindFirst(tp).GetSequence().Identifier;
 		return tp.GetProperty(name)!;
 	}
 
 	public List<PropertyInfo> GetPrimaryKeyProperties()
 	{
 		var tp = GetInstanceType();
-		return ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => tp.GetProperty(x.Identifer)!).ToList();
+		return ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => tp.GetProperty(x.Identifier)!).ToList();
 	}
 
 	public List<ColumnMap> GetPrimaryKeyColumnMap()
 	{
 		var tp = GetInstanceType();
-		var props = ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => x.Identifer).ToList();
+		var props = ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => x.Identifier).ToList();
 		return TypeMap.ColumnMaps.Where(x => props.Contains(x.PropertyName)).ToList();
 	}
 
 	public List<ColumnMap> GetSubordinationColumnMap()
 	{
 		var tp = GetInstanceType();
-		var props = ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => x.Identifer).ToList();
+		var props = ObjectRelationMapper.FindFirst(tp).GetPrimaryKeys().Select(x => x.Identifier).ToList();
 		return TypeMap.ColumnMaps.Where(x => !props.Contains(x.PropertyName)).ToList();
 	}
 }

--- a/src/RedOrb/Mapping/RowMapper.cs
+++ b/src/RedOrb/Mapping/RowMapper.cs
@@ -1,5 +1,4 @@
-﻿using Dapper;
-using System.Collections;
+﻿using System.Collections;
 using System.Data;
 using Utf8Json;
 

--- a/src/RedOrb/RedOrb.csproj
+++ b/src/RedOrb/RedOrb.csproj
@@ -1,53 +1,53 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <PackageProjectUrl>https://github.com/mk3008/RedOrb</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/mk3008/RedOrb</RepositoryUrl>
-    <PackageTags>SQL;ORM;Carbunql</PackageTags>
-    <AssemblyVersion></AssemblyVersion>
-    <Copyright>Copyright (c) MSugiura 2023</Copyright>
-    <PackageReleaseNotes></PackageReleaseNotes>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>0.5.9</Version>
-    <Authors>MSugiura</Authors>
-    <Description>simply object relation mapping framework.</Description>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<PackageProjectUrl>https://github.com/mk3008/RedOrb</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/mk3008/RedOrb</RepositoryUrl>
+		<PackageTags>SQL;ORM;Carbunql</PackageTags>
+		<AssemblyVersion></AssemblyVersion>
+		<Copyright>Copyright (c) MSugiura 2023</Copyright>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Version>0.5.9</Version>
+		<Authors>MSugiura</Authors>
+		<Description>simply object relation mapping framework.</Description>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningLevel>7</WarningLevel>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<WarningLevel>7</WarningLevel>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningLevel>7</WarningLevel>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<WarningLevel>7</WarningLevel>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove=".github\**" />
-    <EmbeddedResource Remove=".github\**" />
-    <None Remove=".github\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove=".github\**" />
+		<EmbeddedResource Remove=".github\**" />
+		<None Remove=".github\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Carbunql" Version="0.5.6" />
-    <PackageReference Include="Carbunql.Dapper" Version="0.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Utf8Json" Version="1.3.7" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Carbunql" Version="0.7.6" />
+		<PackageReference Include="Carbunql.Dapper" Version="0.6.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+		<PackageReference Include="Utf8Json" Version="1.3.7" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/src/RedOrb/SelectQueryExtension.cs
+++ b/src/RedOrb/SelectQueryExtension.cs
@@ -1,6 +1,5 @@
 ﻿using Carbunql;
 using Carbunql.Building;
-using Carbunql.Clauses;
 using Carbunql.Values;
 using RedOrb.Mapping;
 

--- a/src/RedOrb/SelectQueryExtension.cs
+++ b/src/RedOrb/SelectQueryExtension.cs
@@ -15,9 +15,9 @@ internal static class SelectQueryExtension
 		var pkeys = def.GetPrimaryKeys();
 		pkeys.ForEach(column =>
 		{
-			var name = map.TableAlias + column.Identifer;
+			var name = map.TableAlias + column.Identifier;
 			sq.Select(t, column.ColumnName).As(name);
-			map.ColumnMaps.Add(new() { ColumnName = name, PropertyName = column.Identifer });
+			map.ColumnMaps.Add(new() { ColumnName = name, PropertyName = column.Identifier });
 		});
 	}
 
@@ -26,11 +26,11 @@ internal static class SelectQueryExtension
 		var t = sq.GetSelectableTables().Where(x => x.Alias == map.TableAlias).First();
 
 		var pkeys = def.GetPrimaryKeys();
-		def.ColumnDefinitions.Where(x => !string.IsNullOrEmpty(x.Identifer) && !pkeys.Contains(x)).ToList().ForEach(column =>
+		def.ColumnDefinitions.Where(x => !string.IsNullOrEmpty(x.Identifier) && !pkeys.Contains(x)).ToList().ForEach(column =>
 		{
-			var name = map.TableAlias + column.Identifer;
+			var name = map.TableAlias + column.Identifier;
 			sq.Select(t, column.ColumnName).As(name);
-			map.ColumnMaps.Add(new() { ColumnName = name, PropertyName = column.Identifer });
+			map.ColumnMaps.Add(new() { ColumnName = name, PropertyName = column.Identifier });
 		});
 	}
 
@@ -55,7 +55,7 @@ internal static class SelectQueryExtension
 		{
 			foreach (var item in container.Relations)
 			{
-				var parentColumn = destination.GetPrimaryKeys().Where(x => x.Identifer == item.ParentIdentifer).First();
+				var parentColumn = destination.GetPrimaryKeys().Where(x => x.Identifier == item.ParentIdentifer).First();
 				x.Condition(new ColumnValue(fromMap.TableAlias, item.ColumnName).Equal(x.Table.Alias, parentColumn.ColumnName));
 			}
 		});

--- a/test/PostgresSample/CascadeTest.cs
+++ b/test/PostgresSample/CascadeTest.cs
@@ -212,7 +212,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 		var loadedBlog = cn.Load<Blog>(x =>
 		{
 			var def = ObjectRelationMapper.FindFirst<Blog>();
-			var column = def.ColumnDefinitions.Where(x => x.Identifer == nameof(Blog.BlogId)).First().ColumnName;
+			var column = def.ColumnDefinitions.Where(x => x.Identifier == nameof(Blog.BlogId)).First().ColumnName;
 
 			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();
@@ -248,7 +248,7 @@ public class CascadeTest : IClassFixture<PostgresDB>
 		var loadedBlog = cn.Load<Blog>(x =>
 		{
 			var def = ObjectRelationMapper.FindFirst<Blog>();
-			var column = def.ColumnDefinitions.Where(x => x.Identifer == nameof(Blog.BlogId)).First().ColumnName;
+			var column = def.ColumnDefinitions.Where(x => x.Identifier == nameof(Blog.BlogId)).First().ColumnName;
 
 			x.Where(x.FromClause!, column).Equal(x.AddParameter(":id", newBlog.BlogId));
 		}).First();

--- a/test/PostgresSample/DbTableDefinitionTest.cs
+++ b/test/PostgresSample/DbTableDefinitionTest.cs
@@ -1,73 +1,72 @@
 ﻿using Microsoft.Extensions.Logging;
 using RedOrb;
-using RedOrb.Attributes;
 using Xunit.Abstractions;
 
 namespace PostgresSample;
 
 public class DbTableDefinitionTest
 {
-	public DbTableDefinitionTest(ITestOutputHelper output)
-	{
-		Logger = new UnitTestLogger() { Output = output };
-	}
+    public DbTableDefinitionTest(ITestOutputHelper output)
+    {
+        Logger = new UnitTestLogger() { Output = output };
+    }
 
-	private readonly UnitTestLogger Logger;
+    private readonly UnitTestLogger Logger;
 
-	[Fact]
-	public void OmitSchemaName()
-	{
-		var table = new DbTableDefinition { TableName = "test" };
-		Assert.Equal("test", table.TableName);
-		Assert.Equal("test", table.TableFullName);
-	}
+    [Fact]
+    public void OmitSchemaName()
+    {
+        var table = new DbTableDefinition { TableName = "test" };
+        Assert.Equal("test", table.TableName);
+        Assert.Equal("test", table.TableFullName);
+    }
 
-	[Fact]
-	public void HasSchemaName()
-	{
-		var table = new DbTableDefinition { SchemaName = "public", TableName = "test" };
-		Assert.Equal("test", table.TableName);
-		Assert.Equal("public.test", table.TableFullName);
-	}
+    [Fact]
+    public void HasSchemaName()
+    {
+        var table = new DbTableDefinition { SchemaName = "public", TableName = "test" };
+        Assert.Equal("test", table.TableName);
+        Assert.Equal("public.test", table.TableFullName);
+    }
 
-	private DbTableDefinition GetDefinition()
-	{
-		var def = new DbTableDefinition
-		{
-			TableName = "test",
-			PKeyIdentifiers = { "test_id" },
-			ColumnContainers = new()
-			{
-				new DbColumnDefinition()
-				{
-					Identifier = "test_id",
-					ColumnName = "test_id",
-					ColumnType = "serial8",
-				},
-				new DbColumnDefinition()
-				{
-					Identifier = "price",
-					ColumnName = "price",
-					ColumnType = "int8"
-				},
-				new DbColumnDefinition()
-				{
-					Identifier = "remarks",
-					ColumnName = "remarks",
-					ColumnType = "text",
-					IsNullable = true,
-				}
-			}
-		};
-		return def;
-	}
+    private DbTableDefinition GetDefinition()
+    {
+        var def = new DbTableDefinition
+        {
+            TableName = "test",
+            PKeyIdentifiers = { "test_id" },
+            ColumnContainers = new()
+            {
+                new DbColumnDefinition()
+                {
+                    Identifier = "test_id",
+                    ColumnName = "test_id",
+                    ColumnType = "serial8",
+                },
+                new DbColumnDefinition()
+                {
+                    Identifier = "price",
+                    ColumnName = "price",
+                    ColumnType = "int8"
+                },
+                new DbColumnDefinition()
+                {
+                    Identifier = "remarks",
+                    ColumnName = "remarks",
+                    ColumnType = "text",
+                    IsNullable = true,
+                }
+            }
+        };
+        return def;
+    }
 
-	[Fact]
-	public void DDL()
-	{
-		var def = GetDefinition();
+    [Fact]
+    public void DDL()
+    {
+        var def = GetDefinition();
 
-		var expect = """
+        var expect = """
 CREATE TABLE IF NOT EXISTS test (
     test_id serial8 NOT NULL,
     price int8 NOT NULL,
@@ -76,11 +75,11 @@ CREATE TABLE IF NOT EXISTS test (
 )
 ;
 """;
-		var actual = def.ToDefinitionQuerySet().ToText();
-		Logger.LogInformation(actual);
+        var actual = def.ToDefinitionQuerySet().ToText();
+        Logger.LogInformation(actual);
 
-		Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
-	}
+        Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
+    }
 
 
 

--- a/test/PostgresSample/DbTableDefinitionTest.cs
+++ b/test/PostgresSample/DbTableDefinitionTest.cs
@@ -35,23 +35,24 @@ public class DbTableDefinitionTest
 		var def = new DbTableDefinition
 		{
 			TableName = "test",
+			PKeyIdentifiers = { "test_id" },
 			ColumnContainers = new()
 			{
 				new DbColumnDefinition()
 				{
+					Identifier = "test_id",
 					ColumnName = "test_id",
-					IsPrimaryKey = true,
 					ColumnType = "serial8",
 				},
 				new DbColumnDefinition()
 				{
-					Identifer = "price",
+					Identifier = "price",
 					ColumnName = "price",
 					ColumnType = "int8"
 				},
 				new DbColumnDefinition()
 				{
-					Identifer = "remarks",
+					Identifier = "remarks",
 					ColumnName = "remarks",
 					ColumnType = "text",
 					IsNullable = true,
@@ -67,132 +68,20 @@ public class DbTableDefinitionTest
 		var def = GetDefinition();
 
 		var expect = """
-create table if not exists test (
-    test_id serial8 not null, 
-    price int8 not null, 
-    remarks text, 
-    primary key(test_id)
+CREATE TABLE IF NOT EXISTS test (
+    test_id serial8 NOT NULL,
+    price int8 NOT NULL,
+    remarks text,
+    CONSTRAINT pk_test PRIMARY KEY (test_id)
 )
+;
 """;
-		var actual = def.ToCreateTableCommandText();
+		var actual = def.ToDefinitionQuerySet().ToText();
 		Logger.LogInformation(actual);
 
 		Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
 	}
 
-	[Fact]
-	public void DDL_PrimaryKeys()
-	{
-		var def = GetDefinition();
-		var col = def.ColumnDefinitions.Where(x => x.ColumnName == "price").First();
-		col.IsPrimaryKey = true;
 
-		var expect = """
-create table if not exists test (
-    test_id serial8 not null, 
-    price int8 not null, 
-    remarks text, 
-    primary key(test_id, price)
-)
-""";
-		var actual = def.ToCreateTableCommandText();
-		Logger.LogInformation(actual);
 
-		Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
-	}
-
-	[Fact]
-	public void DDL_UniqueKey()
-	{
-		var def = GetDefinition();
-		var col = def.ColumnDefinitions.Where(x => x.ColumnName == "price").First();
-		col.IsUniqueKey = true;
-
-		var expect = """
-create table if not exists test (
-    test_id serial8 not null, 
-    price int8 not null, 
-    remarks text, 
-    primary key(test_id), 
-    unique(price)
-)
-""";
-		var actual = def.ToCreateTableCommandText();
-		Logger.LogInformation(actual);
-
-		Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
-	}
-
-	[Fact]
-	public void DDL_UniqueKeys()
-	{
-		var def = GetDefinition();
-		def.ColumnDefinitions.Where(x => x.ColumnName == "price").First().IsUniqueKey = true;
-		def.ColumnDefinitions.Where(x => x.ColumnName == "remarks").First().IsUniqueKey = true;
-
-		var expect = """
-create table if not exists test (
-    test_id serial8 not null, 
-    price int8 not null, 
-    remarks text, 
-    primary key(test_id), 
-    unique(price, remarks)
-)
-""";
-		var actual = def.ToCreateTableCommandText();
-		Logger.LogInformation(actual);
-
-		Assert.Equal(expect.ToValidateText(), actual.ToValidateText());
-	}
-
-	[Fact]
-	public void DDL_Index()
-	{
-		var def = GetDefinition();
-		def.Indexes.Add(new DbIndexDefinition()
-		{
-			Identifers = { "price" }
-		});
-
-		var expect = """
-create index if not exists i1_test on test (price)
-""";
-		var actuals = def.ToCreateIndexCommandTexts().ToList();
-		Assert.Single(actuals);
-
-		Logger.LogInformation(actuals[0]);
-
-		Assert.Equal(expect.ToValidateText(), actuals[0].ToValidateText());
-	}
-
-	[Fact]
-	public void DDL_Indexes()
-	{
-		var def = GetDefinition();
-		def.Indexes.Add(new DbIndexDefinition()
-		{
-			Identifers = { "price" }
-		});
-		def.Indexes.Add(new DbIndexDefinition()
-		{
-			Identifers = { "price", "remarks" },
-			IsUnique = true
-		});
-
-		var expect0 = """
-create index if not exists i1_test on test (price)
-""";
-		var expect1 = """
-create unique index if not exists i2_test on test (price, remarks)
-""";
-
-		var actuals = def.ToCreateIndexCommandTexts().ToList();
-		Assert.Equal(2, actuals.Count);
-
-		Logger.LogInformation(actuals[0]);
-		Logger.LogInformation(actuals[1]);
-
-		Assert.Equal(expect0.ToValidateText(), actuals[0].ToValidateText());
-		Assert.Equal(expect1.ToValidateText(), actuals[1].ToValidateText());
-	}
 }

--- a/test/PostgresSample/DbTableTest.cs
+++ b/test/PostgresSample/DbTableTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using RedOrb;
+﻿using RedOrb;
 using Xunit.Abstractions;
 
 namespace PostgresSample;

--- a/test/PostgresSample/DefaultTest.cs
+++ b/test/PostgresSample/DefaultTest.cs
@@ -61,7 +61,6 @@ public class DefaultTest : IClassFixture<PostgresDB>
 		var newBlog = new Blog { BlogId = 1, Url = "http://blogs.msdn.com/adonet/DefaultTest/CreateTest" };
 
 		// update error
-		Assert.NotNull(newBlog.BlogId);
 		Assert.NotEqual(0, newBlog.BlogId);
 
 		var exception = Assert.Throws<InvalidOperationException>(() =>

--- a/test/PostgresSample/DefinitionBuilderTest.cs
+++ b/test/PostgresSample/DefinitionBuilderTest.cs
@@ -18,18 +18,23 @@ public class DefinitionBuilderTest
 	public void CreateTable()
 	{
 		var def = DefinitionBuilder.Create<Blog>();
-		var sql = def.ToCreateTableCommandText();
+		var sql = def.ToDefinitionQuerySet().ToText();
 
 		var expect = """
-create table if not exists blogs (
-    blog_id serial8 not null, 
-	url text not null, 
-	tags text not null, 
-	created_at timestamp not null default clock_timestamp(), 
-	updated_at timestamp not null default clock_timestamp(), 
-	version numeric not null, 
-	primary key(blog_id)
+CREATE TABLE IF NOT EXISTS blog (
+    blog_id serial8 NOT NULL,
+    url text NOT NULL,
+    tags text NOT NULL,
+    created_at timestamp NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    updated_at timestamp NOT NULL DEFAULT CLOCK_TIMESTAMP(),
+    version numeric NOT NULL,
+    CONSTRAINT pkey_blog PRIMARY KEY (blog_id)
 )
+;
+CREATE UNIQUE INDEX IF NOT EXISTS i0_blog ON blog (
+    url
+)
+;
 """;
 
 		Logger.LogInformation(sql);
@@ -38,34 +43,24 @@ create table if not exists blogs (
 	}
 
 	[Fact]
-	public void CreateIndex()
-	{
-		var def = DefinitionBuilder.Create<Blog>();
-		var sql = def.ToCreateIndexCommandTexts().First();
-
-		var createTableCommand = """
-create unique index if not exists i1_blogs on blogs (url)
-""";
-
-		Logger.LogInformation(sql);
-
-		Assert.Equal(createTableCommand.ToValidateText(), sql.ToValidateText());
-	}
-
-	[Fact]
 	public void CreateTable_HasParentRelation()
 	{
 		var def = DefinitionBuilder.Create<Post>();
-		var sql = def.ToCreateTableCommandText();
+		var sql = def.ToDefinitionQuerySet().ToText();
 
 		var expect = """
-create table if not exists posts (
-	post_id serial8 not null, 
-	blog_id bigint not null, 
-	title text not null, 
-	content text not null, 
-	primary key(post_id)
+CREATE TABLE IF NOT EXISTS post (
+    post_id serial8 NOT NULL,
+    blog_id bigint NOT NULL,
+    title text NOT NULL,
+    content text NOT NULL,
+    CONSTRAINT pk_post PRIMARY KEY (post_id)
 )
+;
+CREATE INDEX IF NOT EXISTS r0_post ON post (
+    blog_id
+)
+;
 """;
 
 		Logger.LogInformation(sql);

--- a/test/PostgresSample/Model.cs
+++ b/test/PostgresSample/Model.cs
@@ -14,11 +14,11 @@ public class Tag
 }
 
 [GeneratePropertyBind(nameof(Posts), nameof(Post.Blog))]
-[DbTable("blogs")]
-[DbIndex(true, nameof(Url))]
+[DbTable(new[] { nameof(BlogId) }, ConstraintName = "pkey_blog")]
+[DbIndex(new[] { nameof(Url) }, IsUnique = true)]
 public partial class Blog
 {
-	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
+	[DbColumn("serial8", IsAutoNumber = true)]
 	public int BlogId { get; set; }
 	[DbColumn("text")]
 	public string Url { get; set; } = string.Empty;
@@ -36,10 +36,10 @@ public partial class Blog
 }
 
 [GeneratePropertyBind(nameof(Comments), nameof(Comment.Post))]
-[DbTable("posts")]
+[DbTable(new[] { nameof(PostId) })]
 public partial class Post
 {
-	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
+	[DbColumn("serial8", IsAutoNumber = true)]
 	public int PostId { get; set; }
 	[DbParentRelationColumn("bigint", nameof(Post.Blog.BlogId))]
 	public Blog Blog { get; set; } = null!;
@@ -52,10 +52,10 @@ public partial class Post
 	public DirtyCheckableCollection<Comment> Comments { get; }
 }
 
-[DbTable("comments")]
+[DbTable(new[] { nameof(CommentId) })]
 public class Comment
 {
-	[DbColumn("serial8", IsAutoNumber = true, IsPrimaryKey = true)]
+	[DbColumn("serial8", IsAutoNumber = true)]
 	public int CommentId { get; set; }
 	[DbColumn("text")]
 	public string CommentText { get; set; } = string.Empty;

--- a/test/PostgresSample/PostgresDB.cs
+++ b/test/PostgresSample/PostgresDB.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Npgsql;
 using RedOrb;
-using System.Data;
 using Testcontainers.PostgreSql;
 
 namespace PostgresSample;
@@ -12,23 +11,23 @@ https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet
 
 public class PostgresDB : IAsyncLifetime
 {
-	private readonly PostgreSqlContainer Container = new PostgreSqlBuilder().WithImage("postgres:15-alpine").Build();
+    private readonly PostgreSqlContainer Container = new PostgreSqlBuilder().WithImage("postgres:15-alpine").Build();
 
-	public Task InitializeAsync()
-	{
-		return Container.StartAsync();
-	}
+    public Task InitializeAsync()
+    {
+        return Container.StartAsync();
+    }
 
-	public Task DisposeAsync()
-	{
-		return Container.DisposeAsync().AsTask();
-	}
+    public Task DisposeAsync()
+    {
+        return Container.DisposeAsync().AsTask();
+    }
 
-	public LoggingDbConnection ConnectionOpenAsNew(ILogger logger)
-	{
-		var cn = new NpgsqlConnection(Container.GetConnectionString());
-		var lcn = new LoggingDbConnection(cn, logger);
-		lcn.Open();
-		return lcn;
-	}
+    public LoggingDbConnection ConnectionOpenAsNew(ILogger logger)
+    {
+        var cn = new NpgsqlConnection(Container.GetConnectionString());
+        var lcn = new LoggingDbConnection(cn, logger);
+        lcn.Open();
+        return lcn;
+    }
 }

--- a/test/PostgresSample/UnitTestInitializer.cs
+++ b/test/PostgresSample/UnitTestInitializer.cs
@@ -1,30 +1,29 @@
-﻿using Dapper;
-using RedOrb;
+﻿using RedOrb;
 using System.Runtime.CompilerServices;
 
 namespace PostgresSample;
 
 internal static class UnitTestInitializer
 {
-	[ModuleInitializer]
-	public static void Initialize()
-	{
-		ObjectRelationMapper.PlaceholderIdentifer = ":";
-		ObjectRelationMapper.Converter = Converter;
-		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetBlogDefinition());
-		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetPostDefinition());
-		ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetCommentDefinition());
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        ObjectRelationMapper.PlaceholderIdentifer = ":";
+        ObjectRelationMapper.Converter = Converter;
+        ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetBlogDefinition());
+        ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetPostDefinition());
+        ObjectRelationMapper.AddTypeHandler(DbTableDefinitionRepository.GetCommentDefinition());
 
-		//Dapper setting
-		CustomTypeMapper.AddTypeHandler(new JsonTypeHandler<List<Tag>>());
-	}
+        //Dapper setting
+        CustomTypeMapper.AddTypeHandler(new JsonTypeHandler<List<Tag>>());
+    }
 
-	private static DbTableDefinition Converter(DbTableDefinition def)
-	{
-		//foreach (var item in def.ColumnDefinitions) 
-		//{
-		//	item.ColumnName = item.ColumnName.ToUpper();
-		//}
-		return def;
-	}
+    private static DbTableDefinition Converter(DbTableDefinition def)
+    {
+        //foreach (var item in def.ColumnDefinitions) 
+        //{
+        //	item.ColumnName = item.ColumnName.ToUpper();
+        //}
+        return def;
+    }
 }


### PR DESCRIPTION
The library "Carbunql" has been updated to version 0.7 (we plan to add a migration function using this library in the future)
In addition to this, we have integrated overlapping functionality between Carbunql and RedOrb.

- Indexes and unique constraints are now managed by DbIndexAttribute. Additionally, you can now specify a constraint name.

- Primary key constraints have been changed to be managed by DbTableAttribute. Additionally, you can now specify a constraint name.

- As a result of the above, the IsPrimaryKey and IsUniqueKey properties have been "removed" from the DbColumnDefinition. Reason: Duplicate functionality.

Fixed a minor spelling error (identifier)